### PR TITLE
Fix SpamAssassin truncation handling

### DIFF
--- a/config.example.yml
+++ b/config.example.yml
@@ -5,9 +5,9 @@ providers:                        # providers to be used for inboxes
   prov1:                          # provider name
     type: openai                  # provider type
     config:                       # provider specific configuration
-      apikey: some-api-key        # apikey
-      model: gpt-4o-mini          # gpt model to use
-      maxsize: 100000             # message size limit for prompt (bytes)
+      apikey: some-api-key        # openai apikey
+      model: gpt-4o-mini          # openai model to use
+      maxsize: 100000             # optional message size limit for prompt (bytes)
       prompt: |                   # prompt to be sent to the model
         Analyze the following email for its spam potential.
         Return a spam score between 0 and 100. Only answer with the number itself.
@@ -24,22 +24,22 @@ providers:                        # providers to be used for inboxes
   prov2:                          # provider name
     type: ollama                  # provider type
     config:                       # provider specific configuration
-      url: http://127.0.0.1:11434 # url
-      model: gpt-oss:20b          # model to use
-      maxsize: 100000             # message size limit for prompt (bytes)
+      url: http://127.0.0.1:11434 # ollama url
+      model: gpt-oss:20b          # ollama model to use
+      maxsize: 100000             # optional message size limit for prompt (bytes)
   prov3:                          # provider name
     type: spamassassin            # provider type
     config:                       # provider specific configuration
       host: 127.0.0.1             # spamassassin host
       port: 783                   # spamassassin port
-      maxsize: 300000             # message size limit
+      maxsize: 1000000            # optional message size limit
       timeout: 10s                # connection timeout
   prov4:                          # provider name
     type: gemini                  # provider type
     config:                       # provider specific configuration
-      apikey: some-api-key        # apikey
-      model: gemini-2.5-flash     # model to use
-      maxsize: 100000             # message size limit for prompt (bytes)
+      apikey: some-api-key        # gemini apikey
+      model: gemini-2.5-flash     # gemini model to use
+      maxsize: 100000             # optional message size limit for prompt (bytes)
 
 whitelists:                       # trusted senders as regexp, not to be analyzed
   whitelist1:                     # example with exact addresses

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -22,7 +22,7 @@ providers:                        # providers to be used for inboxes
     config:                       # provider specific configuration
       apikey: some-api-key        # openai apikey
       model: gpt-4o-mini          # openai model to use
-      maxsize: 100000             # message size limit for prompt (bytes)
+      maxsize: 100000             # optional message size limit for prompt (bytes)
       prompt: |                   # prompt to be sent to the model
         Analyze the following email for its spam potential.
         Return a spam score between 0 and 100. Only answer with the number itself.
@@ -41,13 +41,28 @@ providers:                        # providers to be used for inboxes
     config:                       # provider specific configuration
       url: http://127.0.0.1:11434 # ollama url
       model: gpt-oss:20b          # ollama model to use
-      maxsize: 100000             # message size limit for prompt (bytes)
+      maxsize: 100000             # optional message size limit for prompt (bytes)
   prov3:                          # provider name
     type: spamassassin            # provider type
     config:                       # provider specific configuration
       host: 127.0.0.1             # spamassassin host
       port: 783                   # spamassassin port
-      maxsize: 300000             # message size limit
+      maxsize: 1000000            # optional message size limit
+      timeout: 10s                # connection timeout
+  prov4:                          # provider name
+    type: gemini                  # provider type
+    config:                       # provider specific configuration
+      apikey: some-api-key        # gemini apikey
+      model: gemini-2.5-flash     # gemini model to use
+      maxsize: 100000             # optional message size limit for prompt (bytes)
+
+whitelists:                       # trusted senders as regexp, not to be analyzed
+  whitelist1:                     # example with exact addresses
+    - ^.* <info@example.com>$     # matches <info@example.com>
+    - ^.* <contact@domain.com>$   # matches <contact@domain.com>
+  whitelist2:                     # example with only domain match
+    - ^.* <.*@example.com>$       # matches for all @example.com addresses
+    - ^.* <.*@domain.com>$        # matches for all @domain.com addresses
 
 inboxes:                          # inboxes to be checked
   - schedule: "* * * * *"         # schedule in cron format (when to execute spam analysis)
@@ -62,6 +77,8 @@ inboxes:                          # inboxes to be checked
     minscore: 75                  # min score to detect spam (0-100)
     minage: 0h                    # min age of message
     maxage: 24h                   # max age of message
+    whitelist: whitelist1         # whitelist to use, empty/missing = no whitelist
+
 ```
 
 ## Docker compose

--- a/docs/providers/gemini.md
+++ b/docs/providers/gemini.md
@@ -8,7 +8,7 @@ Configuration options:
 |-----------|---------|----------|--------------------------------------------------|--------------------|
 | `apikey`  | string  | yes      | OpenAI API key                                   | `some-api-key`     |
 | `model`   | string  | yes      | OpenAI model used for classification             | `gemini-2.5-flash` |
-| `maxsize` | integer | yes      | Maximum email size sent to the model (bytes)     | `100000`           |
+| `maxsize` | integer | no       | Maximum email size sent to the model (bytes)     | `100000`           |
 | `prompt`  | string  | no       | The prompt which is sent to the model (optional) | _see below_        |
 
 Example:

--- a/docs/providers/ollama.md
+++ b/docs/providers/ollama.md
@@ -8,7 +8,7 @@ Configuration options:
 |-----------|---------|----------|--------------------------------------------------|--------------------------|
 | `url`     | string  | yes      | Ollama server URL                                | `http://127.0.0.1:11434` |
 | `model`   | string  | yes      | Ollama model name used for classification        | `gpt-oss:20b`            |
-| `maxsize` | integer | yes      | Maximum email size sent to the model (bytes)     | `100000`                 |
+| `maxsize` | integer | no       | Maximum email size sent to the model (bytes)     | `100000`                 |
 | `prompt`  | string  | no       | The prompt which is sent to the model (optional) | _see below_              |
 
 Example:

--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -8,7 +8,7 @@ Configuration options:
 |-----------|---------|----------|--------------------------------------------------|----------------|
 | `apikey`  | string  | yes      | OpenAI API key                                   | `some-api-key` |
 | `model`   | string  | yes      | OpenAI model used for classification             | `gpt-5-mini`   |
-| `maxsize` | integer | yes      | Maximum email size sent to the model (bytes)     | `100000`       |
+| `maxsize` | integer | no       | Maximum email size sent to the model (bytes)     | `100000`       |
 | `prompt`  | string  | no       | The prompt which is sent to the model (optional) | _see below_    |
 
 Example:

--- a/docs/providers/spamassassin.md
+++ b/docs/providers/spamassassin.md
@@ -8,8 +8,8 @@ Configuration options:
 |-----------|----------|----------|----------------------------------------------|-------------|
 | `host`    | string   | yes      | SpamAssassin host                            | `127.0.0.1` |
 | `port`    | integer  | yes      | SpamAssassin port                            | `783`       |
-| `maxsize` | integer  | yes      | Maximum email size sent to the model (bytes) | `300000`    |
-| `timeout` | duration | yes      | Timeout for the request                      | `10s`       |
+| `maxsize` | integer  | no       | Maximum email size sent to the model (bytes) | `300000`    |
+| `timeout` | duration | no       | Timeout for the request                      | `10s`       |
 
 Example:
 
@@ -20,6 +20,6 @@ providers:
     config:
       host: 127.0.0.1
       port: 783
-      maxsize: 300000
+      maxsize: 1000000
       timeout: 10s
 ```

--- a/provider/aibase.go
+++ b/provider/aibase.go
@@ -18,16 +18,20 @@ type AIBase struct {
 
 func (p *AIBase) ValidateConfig(config map[string]string) error {
 
+	var err error
+
 	if config["model"] == "" {
 		return errors.New("ai model is required")
 	}
 	p.model = config["model"]
 
-	n, err := strconv.ParseInt(config["maxsize"], 10, 64)
-	if err != nil || n < 1 {
-		return errors.New("maxsize must be a positive integer")
+	if config["maxsize"] != "" {
+		n, err := strconv.ParseInt(config["maxsize"], 10, 64)
+		if err != nil || n < 1 {
+			return errors.New("maxsize must be a positive integer")
+		}
+		p.maxsize = int(n)
 	}
-	p.maxsize = int(n)
 
 	prompt := `
 Analyze the following email for its spam potential.
@@ -61,7 +65,7 @@ func (p *AIBase) buildPrompt(msg imap.Message) (string, error) {
 	contLen := 0
 	for _, cnt := range msg.Contents {
 		contLen += len(cnt)
-		if contLen > p.maxsize {
+		if p.maxsize > 0 && contLen > p.maxsize {
 			logx.Debugf("skipping bytes for message #%d (%s)", msg.UID, msg.Subject)
 			break
 		}

--- a/provider/spamassassin.go
+++ b/provider/spamassassin.go
@@ -74,6 +74,7 @@ func (p *SpamAssassin) Analyze(msg imap.Message) (int, error) {
 	if len(msg.Raw) > p.maxsize {
 		logx.Debugf("spamassassin: truncating raw message for message #%d (%s)", msg.UID, msg.Subject)
 		rawBytes = msg.Raw[:p.maxsize]
+		rawBytes = append(rawBytes, '\n')
 	} else {
 		rawBytes = msg.Raw
 	}

--- a/provider/spamassassin.go
+++ b/provider/spamassassin.go
@@ -53,8 +53,8 @@ func (p *SpamAssassin) ValidateConfig(config map[string]string) error {
 
 	if config["maxsize"] != "" {
 		n, err := strconv.ParseInt(config["maxsize"], 10, 64)
-		if err != nil || n < 0 {
-			return errors.New("spamassassin maxsize must be >= 0")
+		if err != nil || n < 1 {
+			return errors.New("spamassassin maxsize must be a positive integer")
 		}
 		p.maxsize = int(n)
 	}

--- a/provider/spamassassin.go
+++ b/provider/spamassassin.go
@@ -26,18 +26,19 @@ func (p *SpamAssassin) Name() string {
 }
 
 func (p *SpamAssassin) ValidateConfig(config map[string]string) error {
-	// host and port optional; set defaults
+
 	host := config["host"]
 	if host == "" {
 		host = "127.0.0.1"
 	}
+
 	port := config["port"]
 	if port == "" {
 		port = "783"
 	}
+
 	p.addr = net.JoinHostPort(host, port)
 
-	// timeout optional (seconds)
 	if config["timeout"] == "" {
 		p.timeout = 5 * time.Second
 	} else if to, err := time.ParseDuration(config["timeout"]); err == nil && to > 0 {
@@ -50,12 +51,13 @@ func (p *SpamAssassin) ValidateConfig(config map[string]string) error {
 		p.timeout = time.Duration(t * float64(time.Second))
 	}
 
-	// maxsize required (positive integer)
-	n, err := strconv.ParseInt(config["maxsize"], 10, 64)
-	if err != nil || n < 1 {
-		return errors.New("spamassassin maxsize must be a positive integer")
+	if config["maxsize"] != "" {
+		n, err := strconv.ParseInt(config["maxsize"], 10, 64)
+		if err != nil || n < 0 {
+			return errors.New("spamassassin maxsize must be >= 0")
+		}
+		p.maxsize = int(n)
 	}
-	p.maxsize = int(n)
 
 	return nil
 }
@@ -71,7 +73,7 @@ func (p *SpamAssassin) Init(config map[string]string) error {
 func (p *SpamAssassin) Analyze(msg imap.Message) (int, error) {
 	// Prefer sending the original raw message if available.
 	var rawBytes []byte
-	if len(msg.Raw) > p.maxsize {
+	if p.maxsize > 0 && len(msg.Raw) > p.maxsize {
 		logx.Debugf("spamassassin: truncating raw message for message #%d (%s)", msg.UID, msg.Subject)
 		rawBytes = msg.Raw[:p.maxsize]
 		rawBytes = append(rawBytes, '\n')


### PR DESCRIPTION
This PR fixes the truncation handling of the spamassassin provider by adding an additional linebreak, if the message gets truncated. Additionally the configurations get adjusted and maxsize options are optional from now on.