### PR TITLE
optional database file mapping

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,5 +9,6 @@ RUN GOOS=$TARGETOS GOARCH=$TARGETARCH CGO_ENABLED=0 go build -a -installsuffix c
 FROM alpine:latest
 WORKDIR /app
 COPY --from=build /app/dist/ .
+RUN touch store.db
 EXPOSE 8080
 ENTRYPOINT [ "/app/imap-spam-cleaner" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,8 @@ services:
     ports:
       - "8080:8080"
     volumes:
-      - ./config.yml:/app/config.yml:ro
-      - ./store.db:/app/store.db:rw
+      - ./config.yml:/app/config.yml:ro # required
+      - ./store.db:/app/store.db:rw     # optional
 
 # SpamAssassin is an optional service
 #  spamassassin:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,7 +1,7 @@
 # Getting started
 
 - Create `config.yml` matching your inboxes (example below)
-- Prepare empty database file `store.db` to store metrics (if needed)
+- Prepare empty file `store.db` to store metrics (optional)
 - Create `docker-compose.yml` if using docker compose (example below)
 - Start the container with: `docker compose up -d`
 - Or with: `docker run -d --name imap-spam-cleaner -v ./config.yml:/app/config.yml -v ./store.db:/app/store.db dominicgisler/imap-spam-cleaner`
@@ -95,6 +95,6 @@ services:
     ports:
       - "8080:8080"
     volumes:
-      - ./config.yml:/app/config.yml:ro
-      - ./store.db:/app/store.db:rw
+      - ./config.yml:/app/config.yml:ro # required
+      - ./store.db:/app/store.db:rw     # optional
 ```


### PR DESCRIPTION
This PR creates an empty database file inside the image to make the volume mapping optional. If metrics are not required they will still be stored in the file, but the volume mapping is not necessary. Mapping the file is necessary if metrics should be kept.