### PR TITLE
Implement rspamd provider

### DIFF
--- a/app/config.go
+++ b/app/config.go
@@ -25,7 +25,7 @@ type Logging struct {
 }
 
 type Provider struct {
-	Type   string            `yaml:"type"   validate:"required,oneof=openai ollama spamassassin gemini"`
+	Type   string            `yaml:"type"   validate:"required,oneof=openai ollama spamassassin gemini rspamd"`
 	Config map[string]string `yaml:"config" validate:"required"`
 }
 

--- a/config.example.yml
+++ b/config.example.yml
@@ -40,6 +40,11 @@ providers:                        # providers to be used for inboxes
       apikey: some-api-key        # gemini apikey
       model: gemini-2.5-flash     # gemini model to use
       maxsize: 100000             # optional message size limit for prompt (bytes)
+  prov5:                          # provider name
+    type: rspamd                  # provider type
+    config:                       # provider specific configuration
+      url: http://127.0.0.1:11333 # API url
+      timeout: 10s                # API timeout
 
 whitelists:                       # trusted senders as regexp, not to be analyzed
   whitelist1:                     # example with exact addresses

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -9,5 +9,10 @@ services:
     volumes:
       - spamassassin_data:/var/lib/spamassassin
 
+  rspamd:
+    image: rspamd/rspamd:latest
+    ports:
+      - "11333:11333"
+
 volumes:
   spamassassin_data: {}

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -55,6 +55,11 @@ providers:                        # providers to be used for inboxes
       apikey: some-api-key        # gemini apikey
       model: gemini-2.5-flash     # gemini model to use
       maxsize: 100000             # optional message size limit for prompt (bytes)
+  prov5:                          # provider name
+    type: rspamd                  # provider type
+    config:                       # provider specific configuration
+      url: http://127.0.0.1:11333 # API url
+      timeout: 10s                # API timeout
 
 whitelists:                       # trusted senders as regexp, not to be analyzed
   whitelist1:                     # example with exact addresses

--- a/docs/providers/rspamd.md
+++ b/docs/providers/rspamd.md
@@ -1,0 +1,25 @@
+# Rspamd
+
+Uses a Rspamd server for classification.
+
+The tool uses the `/checkv2` endpoint to classify the message.
+The returned `score` and `required_score` will be used to calculate the internal `score` (percentage).
+If you want to rely on the `required_score` of `rspamd`, set the `minscore` option in your inbox to `100`.
+
+Configuration options:
+
+| Field     | Type     | Required | Description                                  | Example                  |
+|-----------|----------|----------|----------------------------------------------|--------------------------|
+| `url`     | string   | yes      | Rspamd API URL                               | `http://127.0.0.1:11333` |
+| `timeout` | duration | no       | Timeout for the request                      | `10s`                    |
+
+Example:
+
+```yaml
+providers:
+  prov1:
+    type: rspamd
+    config:
+      url: http://127.0.0.1:11333
+      timeout: 10s
+```

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -14,7 +14,7 @@ type Provider interface {
 }
 
 func New(t string) (Provider, error) {
-	providers := []Provider{&OpenAI{}, &Ollama{}, &SpamAssassin{}, &Gemini{}}
+	providers := []Provider{&OpenAI{}, &Ollama{}, &SpamAssassin{}, &Gemini{}, &Rspamd{}}
 	for _, provider := range providers {
 		if provider.Name() == t {
 			return provider, nil

--- a/provider/rspamd.go
+++ b/provider/rspamd.go
@@ -1,0 +1,95 @@
+package provider
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/dominicgisler/imap-spam-cleaner/imap"
+)
+
+type Rspamd struct {
+	url     string
+	timeout time.Duration
+}
+
+type RspamdResponse struct {
+	Score         float64 `json:"score"`
+	RequiredScore float64 `json:"required_score"`
+}
+
+func (p *Rspamd) Name() string {
+	return "rspamd"
+}
+
+func (p *Rspamd) ValidateConfig(config map[string]string) error {
+
+	uri, err := url.Parse(config["url"])
+	if err != nil {
+		return err
+	}
+	p.url = uri.String()
+
+	if config["timeout"] == "" {
+		p.timeout = 5 * time.Second
+	} else if to, err := time.ParseDuration(config["timeout"]); err == nil && to > 0 {
+		p.timeout = to
+	} else {
+		t, err := strconv.ParseFloat(config["timeout"], 64)
+		if err != nil || t <= 0 {
+			return errors.New("rspamd timeout must be a duration (eg. 10s, 1m) or a positive number of seconds")
+		}
+		p.timeout = time.Duration(t * float64(time.Second))
+	}
+
+	return nil
+}
+
+func (p *Rspamd) Init(config map[string]string) error {
+	if err := p.ValidateConfig(config); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (p *Rspamd) Analyze(msg imap.Message) (int, error) {
+
+	ctx, cancel := context.WithTimeout(context.Background(), p.timeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodPost,
+		p.url+"/checkv2",
+		bytes.NewReader(msg.Raw),
+	)
+	if err != nil {
+		return 0, err
+	}
+
+	req.Header.Set("Content-Type", "message/rfc822")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return 0, fmt.Errorf("rspamd returned %s", resp.Status)
+	}
+
+	var result RspamdResponse
+	if err = json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return 0, err
+	}
+
+	return int(math.Round(result.Score / result.RequiredScore * 100)), nil
+}


### PR DESCRIPTION
This pull request add the `rspamd` provider.

The provider will:
- send raw message to /checkv2
- calculate internal `score` from `score`/`required_score` (percentage)

If a message reaches the threshold defined in `rspamd` it will result in a `score >= 100`, set `minscore` in your inbox to `100`, if you want to rely on the `rspamd` detection.

Setup of `rspamd` is not part of any documentation of this tool. There is a docker container setup in `docker-compose.dev.yml`, but this is meant for development purposes only (zero configuration).