### PR TITLE
Extend AI prompt options

### DIFF
--- a/config.example.yml
+++ b/config.example.yml
@@ -12,14 +12,8 @@ providers:                        # providers to be used for inboxes
         Analyze the following email for its spam potential.
         Return a spam score between 0 and 100. Only answer with the number itself.
 
-        From: {{.From}}
-        To: {{.To}}
-        Delivered-To: {{.DeliveredTo}}
-        Cc: {{.Cc}}
-        Bcc: {{.Bcc}}
-        Subject: {{.Subject}}
+        {{.RawHeader}}
 
-        Content:
         {{.Content}}
   prov2:                          # provider name
     type: ollama                  # provider type

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -27,14 +27,8 @@ providers:                        # providers to be used for inboxes
         Analyze the following email for its spam potential.
         Return a spam score between 0 and 100. Only answer with the number itself.
 
-        From: {{.From}}
-        To: {{.To}}
-        Delivered-To: {{.DeliveredTo}}
-        Cc: {{.Cc}}
-        Bcc: {{.Bcc}}
-        Subject: {{.Subject}}
+        {{.RawHeader}}
 
-        Content:
         {{.Content}}
   prov2:                          # provider name
     type: ollama                  # provider type

--- a/docs/providers/gemini.md
+++ b/docs/providers/gemini.md
@@ -4,12 +4,12 @@ Uses Gemini to analyze the message.
 
 Configuration options:
 
-| Field     | Type    | Required | Description                                      | Example            |
-|-----------|---------|----------|--------------------------------------------------|--------------------|
-| `apikey`  | string  | yes      | OpenAI API key                                   | `some-api-key`     |
-| `model`   | string  | yes      | OpenAI model used for classification             | `gemini-2.5-flash` |
-| `maxsize` | integer | no       | Maximum email size sent to the model (bytes)     | `100000`           |
-| `prompt`  | string  | no       | The prompt which is sent to the model (optional) | _see below_        |
+| Field     | Type    | Required | Description                                                                 | Example            |
+|-----------|---------|----------|-----------------------------------------------------------------------------|--------------------|
+| `apikey`  | string  | yes      | OpenAI API key                                                              | `some-api-key`     |
+| `model`   | string  | yes      | OpenAI model used for classification                                        | `gemini-2.5-flash` |
+| `maxsize` | integer | no       | Maximum message size sent to the model (bytes), only affects `{{.Content}}` | `100000`           |
+| `prompt`  | string  | no       | The prompt which is sent to the model (optional)                            | _see below_        |
 
 Example:
 

--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -4,6 +4,7 @@
 - [Ollama](ollama.md)
 - [Gemini](gemini.md)
 - [SpamAssassin](spamassassin.md)
+- [Rspamd](rspamd.md)
 
 ## AI
 
@@ -13,14 +14,8 @@ The following prompt is used by the AI providers if no custom prompt is specifie
 Analyze the following email for its spam potential.
 Return a spam score between 0 and 100. Only answer with the number itself.
 
-From: {{.From}}
-To: {{.To}}
-Delivered-To: {{.DeliveredTo}}
-Cc: {{.Cc}}
-Bcc: {{.Bcc}}
-Subject: {{.Subject}}
+{{.RawHeader}}
 
-Content:
 {{.Content}}
 ```
 
@@ -32,4 +27,6 @@ The following placeholders can be used in the prompt:
 - `{{.Cc}}`: message header `Cc`
 - `{{.Bcc}}`: message header `Bcc`
 - `{{.Subject}}`: message subject
-- `{{.Content}}`: message content
+- `{{.Content}}`: message content (cut after `maxsize`)
+- `{{.Raw}}`: full raw message (ignored from `maxsize`)
+- `{{.RawHeader}}`: all message headers (ignored from `maxsize`)

--- a/docs/providers/ollama.md
+++ b/docs/providers/ollama.md
@@ -4,12 +4,12 @@ Uses a local LLM to analyze the message.
 
 Configuration options:
 
-| Field     | Type    | Required | Description                                      | Example                  |
-|-----------|---------|----------|--------------------------------------------------|--------------------------|
-| `url`     | string  | yes      | Ollama server URL                                | `http://127.0.0.1:11434` |
-| `model`   | string  | yes      | Ollama model name used for classification        | `gpt-oss:20b`            |
-| `maxsize` | integer | no       | Maximum email size sent to the model (bytes)     | `100000`                 |
-| `prompt`  | string  | no       | The prompt which is sent to the model (optional) | _see below_              |
+| Field     | Type    | Required | Description                                                                 | Example                  |
+|-----------|---------|----------|-----------------------------------------------------------------------------|--------------------------|
+| `url`     | string  | yes      | Ollama server URL                                                           | `http://127.0.0.1:11434` |
+| `model`   | string  | yes      | Ollama model name used for classification                                   | `gpt-oss:20b`            |
+| `maxsize` | integer | no       | Maximum message size sent to the model (bytes), only affects `{{.Content}}` | `100000`                 |
+| `prompt`  | string  | no       | The prompt which is sent to the model (optional)                            | _see below_              |
 
 Example:
 

--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -4,12 +4,12 @@ Uses OpenAI to analyze the message.
 
 Configuration options:
 
-| Field     | Type    | Required | Description                                      | Example        |
-|-----------|---------|----------|--------------------------------------------------|----------------|
-| `apikey`  | string  | yes      | OpenAI API key                                   | `some-api-key` |
-| `model`   | string  | yes      | OpenAI model used for classification             | `gpt-5-mini`   |
-| `maxsize` | integer | no       | Maximum email size sent to the model (bytes)     | `100000`       |
-| `prompt`  | string  | no       | The prompt which is sent to the model (optional) | _see below_    |
+| Field     | Type    | Required | Description                                                                 | Example        |
+|-----------|---------|----------|-----------------------------------------------------------------------------|----------------|
+| `apikey`  | string  | yes      | OpenAI API key                                                              | `some-api-key` |
+| `model`   | string  | yes      | OpenAI model used for classification                                        | `gpt-5-mini`   |
+| `maxsize` | integer | no       | Maximum message size sent to the model (bytes), only affects `{{.Content}}` | `100000`       |
+| `prompt`  | string  | no       | The prompt which is sent to the model (optional)                            | _see below_    |
 
 Example:
 

--- a/imap/imap.go
+++ b/imap/imap.go
@@ -127,6 +127,17 @@ func (i *Imap) LoadMessages() ([]Message, error) {
 			continue
 		}
 
+		var rawHeader []byte
+		headers := mr.Header.Fields()
+		for headers.Next() {
+			headerBytes, err := headers.Raw()
+			if err != nil {
+				logx.Warnf("failed to read message fields: %v\n", err)
+				continue
+			}
+			rawHeader = append(rawHeader, headerBytes...)
+		}
+
 		message := Message{
 			UID:         msg.UID,
 			DeliveredTo: mr.Header.Get("Delivered-To"),
@@ -137,7 +148,8 @@ func (i *Imap) LoadMessages() ([]Message, error) {
 			Subject:     msg.Envelope.Subject,
 			Contents:    []string{},
 			Date:        msg.InternalDate,
-			Raw:         b, // Raw original message bytes. Useful for traditional spam filters.
+			Raw:         b,
+			RawHeader:   rawHeader,
 		}
 
 		if i.cfg.MinAge > 0 && message.Date.After(time.Now().Add(-i.cfg.MinAge)) || i.cfg.MaxAge > 0 && message.Date.Before(time.Now().Add(-i.cfg.MaxAge)) {

--- a/imap/message.go
+++ b/imap/message.go
@@ -17,4 +17,5 @@ type Message struct {
 	Contents    []string
 	Date        time.Time
 	Raw         []byte
+	RawHeader   []byte
 }

--- a/provider/aibase.go
+++ b/provider/aibase.go
@@ -38,12 +38,7 @@ func (p *AIBase) ValidateConfig(config map[string]string) error {
 Analyze the following email for its spam potential.
 Return a spam score between 0 and 100. Only answer with the number itself.
 
-From: {{.From}}
-To: {{.To}}
-Delivered-To: {{.DeliveredTo}}
-Cc: {{.Cc}}
-Bcc: {{.Bcc}}
-Subject: {{.Subject}}
+{{.RawHeader}}
 
 Content:
 {{.Content}}
@@ -81,6 +76,8 @@ func (p *AIBase) buildPrompt(msg imap.Message) (string, error) {
 		Bcc         string
 		Subject     string
 		Content     string
+		Raw         string
+		RawHeader   string
 	}
 
 	var buf bytes.Buffer
@@ -92,6 +89,8 @@ func (p *AIBase) buildPrompt(msg imap.Message) (string, error) {
 		Bcc:         msg.Bcc,
 		Subject:     msg.Subject,
 		Content:     cont.String(),
+		Raw:         string(msg.Raw),
+		RawHeader:   string(msg.RawHeader),
 	}); err != nil {
 		return "", errors.New("prompt template error: " + err.Error())
 	}


### PR DESCRIPTION
This PR adds new variables to AI prompts:
- `{{.Raw}}` - full message
- `{{.RawHeader}}` - all message headers

Important: these values are excluded from `maxsize`.