### PR TITLE
Extend API filters

### DIFF
--- a/database/queries/run/summary.sql
+++ b/database/queries/run/summary.sql
@@ -9,5 +9,6 @@ SELECT
     SUM(`moved_count`) AS `moved_count`
 FROM `run`
 WHERE (? = '' OR `inbox` = ?)
+AND (? IS NULL OR `started_at` >= ?)
 GROUP BY `inbox`
 ORDER BY `inbox`;

--- a/database/run.go
+++ b/database/run.go
@@ -39,9 +39,13 @@ func AddRun(run *Run) error {
 	return nil
 }
 
-func ListRunSummaries(inbox string) ([]RunSummary, error) {
+func ListRunSummaries(inbox string, maxAge int) ([]RunSummary, error) {
+	var minDate *time.Time
+	if maxAge > 0 {
+		minDate = new(time.Now().Add(-time.Second * time.Duration(maxAge)))
+	}
 	var summaries []RunSummary
-	if err := db.Select(&summaries, query("run/summary"), inbox, inbox); err != nil {
+	if err := db.Select(&summaries, query("run/summary"), inbox, inbox, minDate, minDate); err != nil {
 		return nil, err
 	}
 	return summaries, nil

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -14,9 +14,10 @@ Returns one summary entry per inbox. Each entry contains the first recorded run,
 
 ### Query parameters
 
-| Name    | Required | Description                         |
-|---------|----------|-------------------------------------|
-| `inbox` | no       | Limits the summary to one inbox.    |
+| Name     | Required | Description                                                |
+|----------|----------|------------------------------------------------------------|
+| `inbox`  | no       | Limits the summary to one inbox.                           |
+| `maxage` | no       | Number of seconds, limits the runs to use for the summary. |
 
 ### Example request unfiltered
 
@@ -66,6 +67,37 @@ curl "http://localhost:8080/runs/summary?inbox=info@example.com"
   "failed_count": 2,
   "moved_count": 37
 }
+```
+
+### Example request to only show stats for the last day
+
+```console
+curl "http://localhost:8080/runs/summary?maxage=86400"
+```
+
+```json
+[
+  {
+    "inbox": "test@example.com",
+    "run_count": 10,
+    "first_run_at": "2026-05-23 08:00:00+00:00",
+    "last_run_at": "2026-05-23 11:55:00+00:00",
+    "message_count": 100,
+    "skipped_count": 10,
+    "failed_count": 2,
+    "moved_count": 88
+  },
+  {
+    "inbox": "info@example.com",
+    "run_count": 20,
+    "first_run_at": "2026-05-23 08:00:00+00:00",
+    "last_run_at": "2026-05-23 11:55:00+00:00",
+    "message_count": 200,
+    "skipped_count": 20,
+    "failed_count": 4,
+    "moved_count": 176
+  }
+]
 ```
 
 When `inbox` is omitted, an array of summaries will be returned.

--- a/handler/run_summary.go
+++ b/handler/run_summary.go
@@ -3,20 +3,35 @@ package handler
 import (
 	"encoding/json"
 	"net/http"
+	"strconv"
 
 	"github.com/dominicgisler/imap-spam-cleaner/database"
+	"github.com/dominicgisler/imap-spam-cleaner/logx"
 )
 
 func RunSummary(w http.ResponseWriter, r *http.Request) {
+
 	if r.Method != http.MethodGet {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
 
+	var err error
+	var maxAge int
+	if r.URL.Query().Has("maxage") {
+		maxAge, err = strconv.Atoi(r.URL.Query().Get("maxage"))
+		if err != nil {
+			http.Error(w, "could not parse maxage", http.StatusBadRequest)
+			logx.Errorf("could not parse maxage: %s", err)
+			return
+		}
+	}
+
 	inbox := r.URL.Query().Get("inbox")
-	summaries, err := database.ListRunSummaries(inbox)
+	summaries, err := database.ListRunSummaries(inbox, maxAge)
 	if err != nil {
 		http.Error(w, "could not load run summaries", http.StatusInternalServerError)
+		logx.Errorf("could not load run summaries: %s", err)
 		return
 	}
 
@@ -29,11 +44,13 @@ func RunSummary(w http.ResponseWriter, r *http.Request) {
 
 	if err != nil {
 		http.Error(w, "could not load run summary", http.StatusInternalServerError)
+		logx.Errorf("could not load run summary: %s", err)
 		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	if _, err = w.Write(res); err != nil {
 		http.Error(w, "could not write response", http.StatusInternalServerError)
+		logx.Errorf("could not write response: %s", err)
 	}
 }


### PR DESCRIPTION
This PR extends the API filters by adding a `maxage` parameter (number of seconds). This parameter can be used to limit the summary (eg. `maxage=86400` = only use last 24h)